### PR TITLE
Fix pip install codec error on windows

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages
 from distutils.core import setup
 
 
-with open('README.md') as file:
+with open('README.md', encoding='utf-8') as file:
     long_desc = file.read()
 
 __version__ = "7.9.8"


### PR DESCRIPTION
In Python, when you use pip to install packages, the default encoding during the compilation process is not directly determined by Python or pip, but by the default encoding of the compiler and operating system used by Python. We need to set the encoding to avoid compilation failures under different encodings. Here is the error I encountered in my environment:

(quick_trade)` PS C:\Workspace\trade\cxtt> pip install quick-trade
Collecting quick-trade
  Downloading quick_trade-7.9.8.tar.gz (39 kB)
  Preparing metadata (setup.py) ... error
  error: subprocess-exited-with-error
  
  × python setup.py egg_info did not run successfully.
  │ exit code: 1
  ╰─> [6 lines of output]
      Traceback (most recent call last):
        File "<string>", line 2, in <module>
        File "<pip-setuptools-caller>", line 34, in <module>
        File "C:\Users\xyn_d\AppData\Local\Temp\pip-install-kz5ubz7u\quick-trade_f137003798a94543b271ad8f7c01c32a\setup.py", line 7, in <module>
          long_desc = file.read()
      UnicodeDecodeError: 'gbk' codec can't decode byte 0x80 in position 715: illegal multibyte sequence
      [end of output]

  note: This error originates from a subprocess, and is likely not a problem with pip.
error: metadata-generation-failed

× Encountered error while generating package metadata.
╰─> See above for output.

note: This is an issue with the package mentioned above, not pip.
hint: See above for details.
